### PR TITLE
Don't envelop fragments in documents.

### DIFF
--- a/lib/rails/dom/testing/assertions/selector_assertions.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions.rb
@@ -62,7 +62,9 @@ module Rails
           selector = args.first
 
           begin
-            nodeset(root).css(selector)
+            root.css(selector).tap do |matches|
+              return nodeset(root).css(selector) if matches.empty?
+            end
           rescue Nokogiri::CSS::SyntaxError => e
             ActiveSupport::Deprecation.warn("The assertion was not run because of an invalid css selector.\n#{e}", caller(2))
             return
@@ -308,7 +310,7 @@ module Rails
             elsif previous_selection
               previous_selection
             else
-              nodeset document_root_element
+              document_root_element
             end
           end
 

--- a/test/selector_assertions_test.rb
+++ b/test/selector_assertions_test.rb
@@ -279,6 +279,11 @@ EOF
     end
   end
 
+  def test_body_not_present_in_empty_document
+    render_html ''
+    assert_select 'body', 0
+  end
+
   protected
     def render_html(html)
       fake_render(:html, html)
@@ -290,13 +295,13 @@ EOF
 
     def fake_render(content_type, content)
       @html_document = if content_type == :xml
-        Nokogiri::XML::Document.parse(content)
+        Nokogiri::XML::DocumentFragment.parse(content)
       else
-        Nokogiri::HTML::Document.parse(content)
+        Nokogiri::HTML::DocumentFragment.parse(content)
       end
     end
 
     def document_root_element
-      @html_document.root
+      @html_document
     end
 end


### PR DESCRIPTION
Prevents a body tag from being matched in an empty document.

This changes the expectations for `document_root_element` so we need to update Rails as well. I'll submit a separate PR once this is merged.

I'm pretty tired of issues like this because it's so hard to figure out if the node being searched from is included in the search or not. We're probably going to have more issues because of that behavior :cry:

Closes #19
