### PR TITLE
Revert "depends on rails 4.2+"

### DIFF
--- a/rails-dom-testing.gemspec
+++ b/rails-dom-testing.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "nokogiri", "~> 1.6.0"
-  spec.add_dependency "activesupport", "~> 4.2"
+  spec.add_dependency "activesupport"
   spec.add_dependency "rails-deprecated_sanitizer", '>= 1.0.1'
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Let revert this until we have a release. Rubygems don't use prelease.
