### PR TITLE
Add some failing test when asserting body class

### DIFF
--- a/test/selector_assertions_test.rb
+++ b/test/selector_assertions_test.rb
@@ -280,8 +280,18 @@ EOF
   end
 
   def test_body_not_present_in_empty_document
-    render_html ''
+    render_html '<div></div>'
     assert_select 'body', 0
+  end
+
+  def test_body_class_can_be_tested
+    render_html '<body class="foo"></body>'
+    assert_select '.foo'
+  end
+
+  def test_body_class_can_be_tested_with_html
+    render_html '<html><body class="foo"><div></div></body></html>'
+    assert_select '.foo'
   end
 
   def document_root_element


### PR DESCRIPTION
This is the reason that @rubys suite is broken.

As we are always using `Nokogiri::HTML::DocumentFragment` to parse the result [it add a body tag](https://github.com/sparklemotion/nokogiri/blob/62e8e5bb014654fe323e8a5e2a8e27a73871a30a/lib/nokogiri/html/document_fragment.rb#L33) and our body tag is ignored. So we can't assert the class of body.

If we always use `Document` we can't fix https://github.com/rails/rails-dom-testing/issues/19.
