### PR TITLE
`assert_dom_attributes_equal` helper

### DIFF
--- a/lib/rails/dom/testing/assertions/dom_assertions.rb
+++ b/lib/rails/dom/testing/assertions/dom_assertions.rb
@@ -23,7 +23,41 @@ module Rails
             assert_not compare_doms(expected_dom, actual_dom), message
           end
 
+          # Compares hash and DOM Node attributes
+          #
+          #   # assert that node attributes are equal to passed hash
+          #   # <div id="foo" class="bar"></div>
+          #
+          #   # node = css_select("div:first")
+          #   # assert_dom_attributes_equal({id: "foo", class: "bar"}, node)
+          def assert_dom_attributes_equal(expected, node, message = nil)
+            actual = node_attributes(node)
+
+            message ||= "Expected: #{expected}\nActual: #{actual}"
+            assert_equal actual, expected, message
+          end
+
+          # The negated form ofassert_dom_attributes_equal
+          #
+          #   # assert that node attributes are not equal to passed hash
+          #   # <div id="foo" class="bar"></div>
+          #
+          #   # node = css_select("div:first")
+          #   # assert_dom_attributes_equal({id: "foo", class: "red"}, node)
+          def assert_dom_attributes_not_equal(expected, node, message = nil)
+            actual = node_attributes(node)
+
+            message ||= "Expected: #{expected}\nActual: #{actual}"
+            assert_not_equal actual, expected, message
+          end
+
           protected
+            def node_attributes(node)
+              normalized = node.attributes.map do |key, value|
+                [key.to_sym, value.to_s]
+              end
+              Hash[normalized]
+            end
 
             def compare_doms(expected, actual)
               return false unless expected.children.size == actual.children.size

--- a/test/dom_assertions_test.rb
+++ b/test/dom_assertions_test.rb
@@ -21,6 +21,20 @@ class DomAssertionsTest < ActiveSupport::TestCase
     assert_dom_equal(attributes, reverse_attributes)
   end
 
+  def test_equal_dom_attributes
+    doc = Nokogiri::HTML('<div id="foo" class="bar"></div>')
+    node = doc.css("div").first
+
+    assert_dom_attributes_equal({id: "foo", class: "bar"}, node)
+  end
+
+  def test_not_equal_dom_attributes
+    doc = Nokogiri::HTML('<div id="foo" class="white red"></div>')
+    node = doc.css("div").first
+
+    assert_dom_attributes_not_equal({id: "foo", class: "bar"}, node)
+  end
+
   def test_dom_not_equal
     assert_dom_not_equal('<a></a>', '<b></b>')
   end


### PR DESCRIPTION
In Activeform we test a lot of inputs:

``` ruby
node = css_select("input#user_name").first
assert_equal "user[name]", node.attr("name")
assert_equal "text", node.attr("type")
assert_equal "input-big", node.attr("class")
```

This could be replaced with one helper:

``` ruby
node = css_select("input#user_name").first
assert_dom_attributes_equal({name: "user[name", type: "text", class: "input-big"})
```
