### PR TITLE
Fix compatibility with rails 4.2

### DIFF
--- a/rails-dom-testing.gemspec
+++ b/rails-dom-testing.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "nokogiri", "~> 1.6.0"
-  spec.add_dependency "activesupport",  ">= 4.2.0.beta", "< 5.0"
+  spec.add_dependency "activesupport",  ">= 4.2.0", "< 5.0"
   spec.add_dependency "rails-deprecated_sanitizer", '>= 1.0.1'
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Fix this bug on upgrading to rails 4.2: 
Bundler could not find compatible versions for gem "activesupport":

```
  In Gemfile:
    rails (~> 4.2) ruby depends on
      actionview (= 4.2.0) ruby depends on
        activesupport (= 4.2.0) ruby

    rails (~> 4.2) ruby depends on
      actionpack (= 4.2.0) ruby depends on
        rails-dom-testing (>= 1.0.5, ~> 1.0) ruby depends on
          activesupport (4.2.0.beta1)
```
