### PR TITLE
Don't depend on the beta version of activesupport

### DIFF
--- a/rails-dom-testing.gemspec
+++ b/rails-dom-testing.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "nokogiri", "~> 1.6.0"
-  spec.add_dependency "activesupport",  ">= 4.2.0.beta", "< 5.0"
+  spec.add_dependency "activesupport",  ">= 4.2.0", "< 5.0"
   spec.add_dependency "rails-deprecated_sanitizer", '>= 1.0.1'
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
The final of activesupport 4.2.0 is out, so depending on the beta version prevents a clean upgrade to rails 4.2.0