### PR TITLE
Various tweaks for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
+sudo: false
+cache: bundler
 rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
+  - 2.2
   - jruby
   - ruby-head
 matrix:


### PR DESCRIPTION
* Use container-based infrastructure, it's quicker generally
* Cache bundler
* Adds ruby 2.2 to the build matrix