### PR TITLE
Handle escaped characters in assert_select_encoded

### DIFF
--- a/lib/rails/dom/testing/assertions/selector_assertions.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions.rb
@@ -219,7 +219,9 @@ module Rails
           end
 
           content = nodeset(element || @selected).map do |elem|
-            elem.children.select(&:cdata?).map(&:content)
+            elem.children.select do |child|
+              child.cdata? || (child.text? && !child.blank?)
+            end.map(&:content)
           end.join
 
           selected = Nokogiri::HTML::DocumentFragment.parse(content)

--- a/test/selector_assertions_test.rb
+++ b/test/selector_assertions_test.rb
@@ -245,9 +245,7 @@ class AssertSelectTest < ActiveSupport::TestCase
     </item>
     <item>
       <description>
-        <![CDATA[
-          <p>Test 2</p>
-        ]]>
+        &lt;p&gt;Test 2&lt;/p&gt;
       </description>
     </item>
   </channel>


### PR DESCRIPTION
Accept non-blank text nodes within `assert_select_encoded`. I'm no Nokogiri or even XML expert, so feedback on this approach is very welcome.

Fixes #42