### PR TITLE
Stop catching Nokogiri::CSS::SyntaxError

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,9 @@ Doms are compared via `assert_dom_equal` and `assert_dom_not_equal`.
 Elements are asserted via `assert_select`, `assert_select_encoded`, `assert_select_email` and a subset of the dom can be selected with `css_select`.
 The gem is developed for Rails 4.2 and above, and will not work on previous versions.
 
-## Deprecation warnings when upgrading to Rails 4.2:
+## Nokogiri::CSS::SyntaxError exceptions when upgrading to Rails 4.2:
 
-Nokogiri is slightly more strict about the format of css selectors than the previous implementation. That's why you have warnings like:
-
-```
-DEPRECATION WARNING: The assertion was not run because of an invalid css selector.
-```
+Nokogiri is slightly stricter about the format of CSS selectors than the previous implementation.
 
 Check the 4.2 release notes [section on `assert_select`](http://edgeguides.rubyonrails.org/4_2_release_notes.html#assert-select) for help.
 

--- a/lib/rails/dom/testing/assertions/selector_assertions.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions.rb
@@ -62,9 +62,6 @@ module Rails
           root = args.size == 1 ? document_root_element : args.shift
 
           nodeset(root).css(args.first)
-        rescue Nokogiri::CSS::SyntaxError => e
-          ActiveSupport::Deprecation.warn("The assertion was not run because of an invalid css selector.\n#{e}", caller(2))
-          return
         end
 
         # An assertion that selects elements and makes one or more equality tests.
@@ -177,9 +174,6 @@ module Rails
 
             nest_selection(matches, &block) if block_given? && !matches.empty?
           end
-        rescue Nokogiri::CSS::SyntaxError => e
-          ActiveSupport::Deprecation.warn("The assertion was not run because of an invalid css selector.\n#{e}", caller(2))
-          return
         end
 
         # Extracts the content of an element, treats it as encoded HTML and runs

--- a/test/selector_assertions_test.rb
+++ b/test/selector_assertions_test.rb
@@ -220,15 +220,15 @@ class AssertSelectTest < ActiveSupport::TestCase
   # testing invalid selectors
   def test_assert_select_with_invalid_selector
     render_html '<a href="http://example.com">hello</a>'
-    assert_deprecated do
-      assert_nil assert_select("[href=http://example.com]")
+    assert_raises Nokogiri::CSS::SyntaxError do
+      assert_select("[href=http://example.com]")
     end
   end
 
   def test_css_select_with_invalid_selector
     render_html '<a href="http://example.com">hello</a>'
-    assert_deprecated do
-      assert_nil css_select("[href=http://example.com]")
+    assert_raises Nokogiri::CSS::SyntaxError do
+      css_select("[href=http://example.com]")
     end
   end
 


### PR DESCRIPTION
Skipping over an assertion in the hopes the developer will see the deprecation warning seems like the wrong approach to this. 

cc @rafaelfranca 