### PR TITLE
Include MIT-LICENSE in the gem file.

### DIFF
--- a/rails-dom-testing.gemspec
+++ b/rails-dom-testing.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/rails/rails-dom-testing"
   spec.license       = "MIT"
 
-  spec.files         = Dir["lib/**/*", "README.md", "LICENSE.txt", "CHANGELOG.md"]
+  spec.files         = Dir["lib/**/*", "README.md", "MIT-LICENSE", "CHANGELOG.md"]
   spec.test_files    = Dir["test/**/*"]
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
Hi,
I found the license file was not included in your gem file.
Because you have changed the license file name from LICENSE.txt to MIT-LICENSE.
Could you marge this to master branch?
Thanks.
