### PR TITLE
Fix master build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .config
 .yardoc
 Gemfile.lock
+gemfiles/*.lock
 InstalledFiles
 _yardoc
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ cache: bundler
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1
-  - 2.2
-  - 2.3.0
+  - 2.1.10
+  - 2.2.5
+  - 2.3.1
   - jruby
   - ruby-head
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,20 @@ rvm:
   - 2.3.1
   - jruby
   - ruby-head
+gemfile:
+  - gemfiles/active_support_4.2.gemfile
+  - gemfiles/active_support_5.0.gemfile
 matrix:
   fast_finish: true
+  exclude:
+    - rvm: 1.9.3
+      gemfile: gemfiles/active_support_5.0.gemfile
+    - rvm: 2.0.0
+      gemfile: gemfiles/active_support_5.0.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/active_support_5.0.gemfile
+    - rvm: jruby
+      gemfile: gemfiles/active_support_5.0.gemfile
 notifications:
   email: false
   irc:

--- a/gemfiles/active_support_4.2.gemfile
+++ b/gemfiles/active_support_4.2.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~> 4.2.0"
+
+gemspec path: "../"

--- a/gemfiles/active_support_5.0.gemfile
+++ b/gemfiles/active_support_5.0.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~> 5.0.0"
+
+gemspec path: "../"


### PR DESCRIPTION
Active Support 5.0.0 only supports Ruby 2.2 or more.
Fix to perform a test of Active Support 5.0.0 only in Ruby 2.2 or more.

Fixes #56