### PR TITLE
Update to nokogiri ~> 1.7.1 to fix CVE

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,25 +3,25 @@ PATH
   specs:
     rails-dom-testing (2.0.2)
       activesupport (>= 4.2.0, < 6.0)
-      nokogiri (~> 1.6)
+      nokogiri (>= 1.6, < 1.8)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.1)
+    activesupport (5.0.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    concurrent-ruby (1.0.4)
-    i18n (0.7.0)
+    concurrent-ruby (1.0.5)
+    i18n (0.8.1)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
-    nokogiri (1.7.0)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     rake (12.0.0)
-    thread_safe (0.3.5)
-    tzinfo (1.2.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.3)
       thread_safe (~> 0.1)
 
 PLATFORMS

--- a/gemfiles/active_support_5.0.gemfile
+++ b/gemfiles/active_support_5.0.gemfile
@@ -2,6 +2,6 @@ source "https://rubygems.org"
 
 gem "activesupport", "~> 5.0.0"
 
-gem "nokogiri", ">= 1.7.0"
+gem "nokogiri", ">= 1.7.1"
 
 gemspec path: "../"

--- a/rails-dom-testing.gemspec
+++ b/rails-dom-testing.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir["test/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "nokogiri", "~> 1.6"
+  spec.add_dependency "nokogiri", ">= 1.6", "< 1.8"
   spec.add_dependency "activesupport",  ">= 4.2.0", "< 6.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
There has been a CVE security issue reported and fixed on Nokogiri that has been fixed in 1.7.1. See https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#171--2017-03-19 for more info.