### PR TITLE
Update nokogiri to fix security issues.

### DIFF
--- a/rails-dom-testing.gemspec
+++ b/rails-dom-testing.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir["test/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "nokogiri", ">= 1.6"
+  spec.add_dependency "nokogiri", ">= 1.7.2"
   spec.add_dependency "activesupport",  ">= 4.2.0"
 
   spec.add_development_dependency "bundler", ">= 1.3"


### PR DESCRIPTION
The late 1.6 versions of nokogiri, as well as versions 1.7.1 and 1.7.2
contain several security fixes.

https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md