### PR TITLE
Dup selector string when extracting in case it's frozen

### DIFF
--- a/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb
@@ -74,6 +74,7 @@ class HTMLSelector #:nodoc:
       raise ArgumentError, "Expecting a selector as the first argument"
     end
 
+    selector = selector.dup
     context.substitute!(selector, @values)
     selector
   end

--- a/test/selector_assertions_test.rb
+++ b/test/selector_assertions_test.rb
@@ -18,6 +18,11 @@ class AssertSelectTest < ActiveSupport::TestCase
   # Test assert select.
   #
 
+  def test_frozen_selector_substitution
+    render_html %Q{<div id="1">foo</div><div id="2">foo</div>}
+    assert_select "div:match('id', ?)".freeze, /\d+/
+  end
+
   def test_assert_select
     render_html %Q{<div id="1"></div><div id="2"></div>}
     assert_select "div", 2


### PR DESCRIPTION
Looking forward to Ruby 3 where strings will be immutable by default and Ruby 2 with `# frozen_string_literal: true`, this prevents raising modification of frozen string errors.

This is pointing to the `1-0-stable` as it has been fixed on master 😄 

Fixes https://github.com/rails/rails-dom-testing/issues/69