### PR TITLE
Make assert_dom_equal ignore insignificant whitespace

### DIFF
--- a/lib/rails/dom/testing/assertions/dom_assertions.rb
+++ b/lib/rails/dom/testing/assertions/dom_assertions.rb
@@ -3,6 +3,8 @@ module Rails
     module Testing
       module Assertions
         module DomAssertions
+          NODE_PADDING = ' '.freeze
+
           # \Test two HTML strings for equivalency (e.g., equal even when attributes are in another order)
           #
           #   # assert that the referenced method generates the appropriate HTML string
@@ -68,36 +70,54 @@ module Rails
 
             def fragment(text)
               Nokogiri::HTML::DocumentFragment.parse(text).tap do |fragment|
-                squish_insignificant_whitespace(fragment)
+                pad_tags(fragment.children)
+                condense_whitespace(fragment.children)
               end
             end
 
-            def squish_insignificant_whitespace(block_node)
-              # Distill down the textual contents of `block_node` into "runs"
-              # of text nodes that are bridged by regions of whitespace:
-              text_nodes = block_node.children.flat_map { |node| flattened_text_nodes(node) }
-              text_nodes.last.content += ' ' if text_nodes.any?
-              runs = text_nodes.slice_when { |t1, t2| t1.text !~ /\s\z/ || t2.text !~ /\A\s/ }
+            def pad_tags(node)
+              return node.each { |n| pad_tags(n) } if node.is_a?(Nokogiri::XML::NodeSet)
+              return unless node.element?
 
-              runs.each do |run|
-                # Preserve whitespace at the start of each run:
-                squish_or_remove(run.shift, strip_left: false)
-                # Remove whitespace from boundaries within the run:
-                run.each { |text_node| squish_or_remove(text_node, strip_left: true) }
+              if (previous = node.previous_sibling) && previous.text?
+                previous.content += NODE_PADDING
+              else
+                node.add_previous_sibling(NODE_PADDING)
               end
+
+              if (first = node.children.first) && first.text?
+                first.content = NODE_PADDING + first.content
+              else
+                node.prepend_child(NODE_PADDING)
+              end
+
+              if (last = node.children.last) && last.text?
+                last.content = NODE_PADDING + last.content
+              else
+                node.add_child(NODE_PADDING)
+              end
+
+              if (after = node.next_sibling) && after.text?
+                after.content += NODE_PADDING
+              else
+                node.add_next_sibling(NODE_PADDING)
+              end
+
+              pad_tags(node.children)
             end
 
-            def squish_or_remove(text_node, strip_left:)
-              text = text_node.text
+            def condense_whitespace(node)
+              if node.is_a?(Nokogiri::XML::NodeSet)
+                node.each { |element| condense_whitespace(element) }
+              elsif node.element?
+                condense_whitespace(node.children)
+              else
+                text = node.text
+                text.gsub!(/\s+/, ' ')
+                text.strip!
 
-              text.gsub!(/\s+/, ' ')
-              text.lstrip! if strip_left
-              text.empty? ? text_node.remove : text_node.content = text
-            end
-
-            def flattened_text_nodes(node)
-              return [node] unless node.element?
-              node.children.flat_map { |child| flattened_text_nodes(child) }
+                text.empty? ? node.remove : node.content = text
+              end
             end
         end
       end

--- a/lib/rails/dom/testing/assertions/dom_assertions.rb
+++ b/lib/rails/dom/testing/assertions/dom_assertions.rb
@@ -111,7 +111,7 @@ module Rails
                 node.each { |element| condense_whitespace(element) }
               elsif node.element?
                 condense_whitespace(node.children)
-              else
+              elsif node.text?
                 text = node.text
                 text.gsub!(/\s+/, ' ')
                 text.strip!

--- a/test/dom_assertions_test.rb
+++ b/test/dom_assertions_test.rb
@@ -62,6 +62,13 @@ world
     assert_dom_not_equal(with_space, without_space)
   end
 
+  def test_explicit_processing_of_text_whitespace
+    valid_cdata = %{<script>//<![CDATA[\n1+1\n//]]></script>}
+    incorrect   = %{<script>//<![CDATA[ 1+1 //]]></script>}
+
+    assert_dom_not_equal(incorrect, valid_cdata)
+  end
+
   def test_dom_not_equal
     assert_dom_not_equal('<a></a>', '<b></b>')
   end

--- a/test/dom_assertions_test.rb
+++ b/test/dom_assertions_test.rb
@@ -22,29 +22,44 @@ class DomAssertionsTest < ActiveSupport::TestCase
   end
 
   def test_dom_equal_up_to_whitespace
-    canonical = %{<a> <b>hello </b>world</a>}
-    assert_dom_equal(canonical, %{<a>\n<b> hello </b>\nworld</a>})
+    canonical = %{<a><b>hello</b>world</a>}
+    assert_dom_equal(canonical, %{<a>\n<b>hello </b>\nworld</a>})
     assert_dom_equal(canonical, %{<a> \n <b> hello </b>world</a>})
     assert_dom_equal(canonical, %{<a> \n <b>hello </b>world\n</a>\n})
     assert_dom_equal(canonical, %{<a>\n\t<b>hello </b>\n\tworld</a>})
+  end
+
+  def test_dom_equal_with_indentation
+    canonical = %{<a>hello <b>cruel</b> world</a>}
     assert_dom_equal(canonical, <<-HTML)
 <a>
-  <b>hello </b>
+  hello
+  <b>cruel</b>
   world
 </a>
     HTML
+
+    assert_dom_equal(canonical, <<-HTML)
+<a>
+hello
+<b>cruel</b>
+world
+</a>
+    HTML
+
+    assert_dom_equal(canonical, <<-HTML)
+<a>hello
+  <b>
+    cruel
+  </b>
+  world</a>
+    HTML
   end
 
-  def test_dom_not_equal_up_with_significant_whitespace
-    with_space    = %{<a><b>hello</b> world</a>}
-    without_space = %{<a><b>hello</b>world</a>}
+  def test_dom_not_equal_with_interior_whitespace
+    with_space    = %{<a><b>hello world</b></a>}
+    without_space = %{<a><b>helloworld</b></a>}
     assert_dom_not_equal(with_space, without_space)
-  end
-
-  def test_dom_not_equal_up_with_boundary_whitespace
-    space_before = %{<a><b>hello </b>world</a>}
-    space_after  = %{<a><b>hello</b> world</a>}
-    assert_dom_not_equal(space_before, space_after)
   end
 
   def test_dom_not_equal

--- a/test/dom_assertions_test.rb
+++ b/test/dom_assertions_test.rb
@@ -21,6 +21,32 @@ class DomAssertionsTest < ActiveSupport::TestCase
     assert_dom_equal(attributes, reverse_attributes)
   end
 
+  def test_dom_equal_up_to_whitespace
+    canonical = %{<a> <b>hello </b>world</a>}
+    assert_dom_equal(canonical, %{<a>\n<b> hello </b>\nworld</a>})
+    assert_dom_equal(canonical, %{<a> \n <b> hello </b>world</a>})
+    assert_dom_equal(canonical, %{<a> \n <b>hello </b>world\n</a>\n})
+    assert_dom_equal(canonical, %{<a>\n\t<b>hello </b>\n\tworld</a>})
+    assert_dom_equal(canonical, <<~HTML)
+      <a>
+        <b>hello </b>
+        world
+      </a>
+    HTML
+  end
+
+  def test_dom_not_equal_up_with_significant_whitespace
+    with_space    = %{<a><b>hello</b> world</a>}
+    without_space = %{<a><b>hello</b>world</a>}
+    assert_dom_not_equal(with_space, without_space)
+  end
+
+  def test_dom_not_equal_up_with_boundary_whitespace
+    space_before = %{<a><b>hello </b>world</a>}
+    space_after  = %{<a><b>hello</b> world</a>}
+    assert_dom_not_equal(space_before, space_after)
+  end
+
   def test_dom_not_equal
     assert_dom_not_equal('<a></a>', '<b></b>')
   end

--- a/test/dom_assertions_test.rb
+++ b/test/dom_assertions_test.rb
@@ -27,11 +27,11 @@ class DomAssertionsTest < ActiveSupport::TestCase
     assert_dom_equal(canonical, %{<a> \n <b> hello </b>world</a>})
     assert_dom_equal(canonical, %{<a> \n <b>hello </b>world\n</a>\n})
     assert_dom_equal(canonical, %{<a>\n\t<b>hello </b>\n\tworld</a>})
-    assert_dom_equal(canonical, <<~HTML)
-      <a>
-        <b>hello </b>
-        world
-      </a>
+    assert_dom_equal(canonical, <<-HTML)
+<a>
+  <b>hello </b>
+  world
+</a>
     HTML
   end
 


### PR DESCRIPTION
Following on from issue #62 and PR #66, I've taken a stab at implementing this. Not suggesting this ready to go, but just trying to keep the discussion alive.

In the past, we've had crude downstream implementations, but I've tried to get something that works with the current Rails approach, and behaves something like an inline formatting context.

Happy to keep working on this, or hand over to @chancancode or another.