### PR TITLE
Updates nokogiri dependency version to >=1.8.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,37 +1,38 @@
 PATH
   remote: .
   specs:
-    rails-dom-testing (2.0.2)
-      activesupport (>= 4.2.0, < 6.0)
-      nokogiri (~> 1.6)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.8.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.1)
+    activesupport (5.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    concurrent-ruby (1.0.4)
-    i18n (0.7.0)
-    mini_portile2 (2.1.0)
+    concurrent-ruby (1.0.5)
+    i18n (0.9.3)
+      concurrent-ruby (~> 1.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.1)
-    nokogiri (1.7.0)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     rake (12.0.0)
-    thread_safe (0.3.5)
-    tzinfo (1.2.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.4)
       thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.3)
+  bundler (>= 1.3)
   minitest
   rails-dom-testing!
   rake
 
 BUNDLED WITH
-   1.13.7
+   1.16.1

--- a/rails-dom-testing.gemspec
+++ b/rails-dom-testing.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir["test/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "nokogiri", ">= 1.6"
+  spec.add_dependency "nokogiri", ">= 1.8.1"
   spec.add_dependency "activesupport",  ">= 4.2.0"
 
   spec.add_development_dependency "bundler", ">= 1.3"


### PR DESCRIPTION
I was checking my gems with bundle audit and got one vulnerability by `nokogiri`:

```
Name: nokogiri
Version: 1.8.0
Advisory: CVE-2017-9050
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1673
Title: Nokogiri gem, via libxml, is affected by DoS and RCE vulnerabilities
Solution: upgrade to >= 1.8.1
```

I thought it's a good idea to update the dependency version so we can avoid this vulnerability :)
Also, I used the latest version of bundle to update the version. If you want to use the `1.13.7` version let me know so I can change it.

Thanks :)