### PR TITLE
Address `warning: mismatched indentations at 'when' with 'case'`

### DIFF
--- a/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb
@@ -87,20 +87,20 @@ class HTMLSelector #:nodoc:
   def extract_equality_tests
     comparisons = {}
     case comparator = @values.shift
-      when Hash
-        comparisons = comparator
-      when String, Regexp
-        comparisons[:text] = comparator
-      when Integer
-        comparisons[:count] = comparator
-      when Range
-        comparisons[:minimum] = comparator.begin
-        comparisons[:maximum] = comparator.end
-      when FalseClass
-        comparisons[:count] = 0
-      when NilClass, TrueClass
-        comparisons[:minimum] = 1
-      else raise ArgumentError, "I don't understand what you're trying to match"
+    when Hash
+      comparisons = comparator
+    when String, Regexp
+      comparisons[:text] = comparator
+    when Integer
+      comparisons[:count] = comparator
+    when Range
+      comparisons[:minimum] = comparator.begin
+      comparisons[:maximum] = comparator.end
+    when FalseClass
+      comparisons[:count] = 0
+    when NilClass, TrueClass
+      comparisons[:minimum] = 1
+    else raise ArgumentError, "I don't understand what you're trying to match"
     end
 
     # By default we're looking for at least one match.


### PR DESCRIPTION
This pull request addresses `warning: mismatched indentations at 'when' with 'case'`and `warning: mismatched indentations at 'else' with 'case'` generated by `ruby 2.6.0dev (2018-04-07 trunk 63108) [x86_64-linux]` 

```ruby
$ bundle exec rake test
/home/yahonda/.rbenv/versions/2.6.0-dev/bin/ruby -w -I"lib:test" -I"/home/yahonda/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/rake-12.0.0/lib" "/home/yahonda/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/rake-12.0.0/lib/rake/rake_test_loader.rb" "test/dom_assertions_test.rb" "test/selector_assertions_test.rb"
... snip ...
/home/yahonda/git/rails-dom-testing/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb:90: warning: mismatched indentations at 'when' with 'case' at 89
/home/yahonda/git/rails-dom-testing/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb:92: warning: mismatched indentations at 'when' with 'case' at 89
/home/yahonda/git/rails-dom-testing/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb:94: warning: mismatched indentations at 'when' with 'case' at 89
/home/yahonda/git/rails-dom-testing/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb:96: warning: mismatched indentations at 'when' with 'case' at 89
/home/yahonda/git/rails-dom-testing/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb:99: warning: mismatched indentations at 'when' with 'case' at 89
/home/yahonda/git/rails-dom-testing/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb:101: warning: mismatched indentations at 'when' with 'case' at 89
/home/yahonda/git/rails-dom-testing/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb:103: warning: mismatched indentations at 'else' with 'case' at 89
Run options: --seed 23218
... snip ...
```

#### How to address these warnings:
These warnings can be easily addressed by using RuboCop. I do not mean to configure it permantently then removed .rubocop.yml and .rubocop_todo.yml at the end of these steps.

* Execute RuboCop with `--auto-gen-config` option
```
$ rubocop --auto-gen-config
```

* Edit .rubocop_todo.yml to replace `Exclude` with `Include` under `Layout/CaseIndentation:`

```
 37 Layout/CaseIndentation:
 38   Include:
 39     - 'lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb'
 40
```

* Execute RuboCop --auto-correct option
```
$ rubocop --auto-correct
```

* Remove .rubocop.yml and .rubocop_todo.yml file
```
$ rm .rubocop.yml .rubocop_todo.yml
```