### PR TITLE
Fix replacement for multiple substitutions

### DIFF
--- a/lib/rails/dom/testing/assertions/selector_assertions/substitution_context.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions/substitution_context.rb
@@ -4,13 +4,10 @@ class SubstitutionContext
   end
 
   def substitute!(selector, values, format_for_presentation = false)
-    selector = selector.dup
-
-    while !values.empty? && substitutable?(values.first) && selector.index(@substitute)
-      selector.sub! @substitute, matcher_for(values.shift, format_for_presentation)
+    selector.gsub @substitute do |match|
+      next match[0] if values.empty? || !substitutable?(values.first)
+      matcher_for(values.shift, format_for_presentation)
     end
-
-    selector
   end
 
   def match(matches, attribute, matcher)
@@ -23,7 +20,7 @@ class SubstitutionContext
       if format_for_presentation
         value.inspect # Avoid to_s so Regexps aren't put in quotes.
       else
-        value.to_s.inspect
+        "\"#{value}\""
       end
     end
 

--- a/test/selector_assertions_test.rb
+++ b/test/selector_assertions_test.rb
@@ -135,6 +135,11 @@ class AssertSelectTest < ActiveSupport::TestCase
     end
   end
 
+  def test_multiple_substitution_values
+    render_html '<input name="foo[12]" value="34">'
+    assert_select ":match('name', ?):match('value', ?)", /\w+\[\d+\]/, /\d+/
+  end
+
   def test_substitution_values_with_values_other_than_string_or_regexp
     render_html %Q{<div id="id_string">symbol</div><div id="1">numeric</div>}
     assert_select "div:match('id', ?)", :id_string do |elements|


### PR DESCRIPTION
Since SubstitutionContext#substitute! uses while/#sub! to replace '?' in
the selector, and the replacement text contains that character, e.g.,
"(?-mix:\\d+)", if the selector requires more than one replacement, the
replaced text is matched by the next iteration.

	# given this assertion
	assert_select "input[name=?][value=?]", /item-\d+/, /\d+/

	# first iteration
	"input[name=\"(?-mix:item-\\d+)\"][value=?]"

	# second iteration
	"input[name=\"(\"(?-mix:\\d+)\"-mix:item-\\d+)\"][value=?]"

This commit uses #gsub to avoid replacing already substituted text.

Fixes #75.