### PR TITLE
Make Nokogiri an optional dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in rails-dom-testing.gemspec
 gemspec
+
+gem "nokogiri", ">= 1.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,37 +1,38 @@
 PATH
   remote: .
   specs:
-    rails-dom-testing (2.0.2)
-      activesupport (>= 4.2.0, < 6.0)
-      nokogiri (~> 1.6)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.1)
+    activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    concurrent-ruby (1.0.4)
-    i18n (0.7.0)
-    mini_portile2 (2.1.0)
+    concurrent-ruby (1.1.5)
+    i18n (1.6.0)
+      concurrent-ruby (~> 1.0)
+    mini_portile2 (2.4.0)
     minitest (5.10.1)
-    nokogiri (1.7.0)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.10.3)
+      mini_portile2 (~> 2.4.0)
     rake (12.0.0)
-    thread_safe (0.3.5)
-    tzinfo (1.2.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.3)
+  bundler (>= 1.3)
   minitest
+  nokogiri (>= 1.6)
   rails-dom-testing!
   rake
 
 BUNDLED WITH
-   1.13.7
+   1.17.3

--- a/lib/rails/dom/testing/assertions.rb
+++ b/lib/rails/dom/testing/assertions.rb
@@ -1,5 +1,11 @@
 require 'active_support/concern'
-require 'nokogiri'
+
+begin
+  gem "nokogiri", ">= 1.6"
+  require 'nokogiri'
+rescue LoadError => e
+  raise LoadError, "Failed to load nokogiri gem. Add gem 'nokogiri', group: [:development, :test] to your Gemfile and run bundle install to enable rails-dom-helpers in your test environment.", e.backtrace
+end
 
 module Rails
   module Dom

--- a/rails-dom-testing.gemspec
+++ b/rails-dom-testing.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir["test/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "nokogiri", ">= 1.6"
   spec.add_dependency "activesupport",  ">= 4.2.0"
 
   spec.add_development_dependency "bundler", ">= 1.3"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
-require 'nokogiri'
 require 'active_support'
 require 'active_support/test_case'
 require 'minitest/autorun'
+require 'rails-dom-testing'
 
 ActiveSupport::TestCase.test_order = :random


### PR DESCRIPTION
In the best practice of basing Docker containers on the smallest base image, I often find myself using `FROM ruby:2.5-alpine` in my Dockerfiles. But because `nokogiri` is a dependency of `rails-dom-testing` and `rails-dom-testing` is a dependency of `actionview`, even for a tiny stateless Rails app you end up installing a bunch of packages like `build-base libxml2-dev libxslt-dev` - even if my app in running in production and by no way loads `rails-dom-testing` - which adds megabytes of dependencies. It's also not uncommon to require `bundle config build.nokogiri --use-system-libraries` to make the image build work.

I'd like to discuss making `nokogiri` not a hard dependency of Rails. This could be achieved by at least 2 ways. Option 1) is make `nokogiri` an optional dependency of `rails-dom-testing`, and ask people add Nokogiri to their gemfile _only_ when they  invoke DOM helpers. This is similar to how ActiveRecord [handles database adapters](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L3-L5). Option 2) is to make  `rails-dom-testing` an optional dependency of ActionView.

I believe that the Rails core wants to encourage the community to adopt integration tests and DOM helpers, so I guess that Option 2) is less desired. This is the reason why I choose Option 1) in this PR.

I'm open for discussion and perhaps there might be more ways to achieve this. My main goal here is to simplify Rails deployment and make it work seamlessly on lightweight container bases like Alpine.