### PR TITLE
make assert_dom_equal ignore insignificant whitespace

### DIFF
--- a/lib/rails/dom/testing/assertions/dom_assertions.rb
+++ b/lib/rails/dom/testing/assertions/dom_assertions.rb
@@ -3,12 +3,14 @@ module Rails
     module Testing
       module Assertions
         module DomAssertions
+          WHITESPACE_REGEXP = /[\s]*\n[\s]*/
+
           # \Test two HTML strings for equivalency (e.g., equal even when attributes are in another order)
           #
           #   # assert that the referenced method generates the appropriate HTML string
           #   assert_dom_equal '<a href="http://www.example.com">Apples</a>', link_to("Apples", "http://www.example.com")
-          def assert_dom_equal(expected, actual, message = nil)
-            expected_dom, actual_dom = fragment(expected), fragment(actual)
+          def assert_dom_equal(expected, actual, message = nil, strict: false)
+            expected_dom, actual_dom = fragment(expected, strict), fragment(actual, strict)
             message ||= "Expected: #{expected}\nActual: #{actual}"
             assert compare_doms(expected_dom, actual_dom), message
           end
@@ -17,8 +19,8 @@ module Rails
           #
           #   # assert that the referenced method does not generate the specified HTML string
           #   assert_dom_not_equal '<a href="http://www.example.com">Apples</a>', link_to("Oranges", "http://www.example.com")
-          def assert_dom_not_equal(expected, actual, message = nil)
-            expected_dom, actual_dom = fragment(expected), fragment(actual)
+          def assert_dom_not_equal(expected, actual, message = nil, strict: false)
+            expected_dom, actual_dom = fragment(expected, strict), fragment(actual, strict)
             message ||= "Expected: #{expected}\nActual: #{actual}"
             assert_not compare_doms(expected_dom, actual_dom), message
           end
@@ -66,7 +68,8 @@ module Rails
 
           private
 
-            def fragment(text)
+            def fragment(text, strict)
+              text = text.gsub(WHITESPACE_REGEXP, '') unless strict
               Nokogiri::HTML::DocumentFragment.parse(text)
             end
         end

--- a/test/dom_assertions_test.rb
+++ b/test/dom_assertions_test.rb
@@ -47,4 +47,52 @@ class DomAssertionsTest < ActiveSupport::TestCase
       %{<a><b c="2" /></a>}
     )
   end
+
+  def test_dom_equal_with_whitespace_strict
+    canonical = %{<a><b>hello</b> world</a>}
+    assert_dom_not_equal(canonical, %{<a>\n<b>hello\n </b> world</a>}, strict: true)
+    assert_dom_not_equal(canonical, %{<a> \n <b>\n hello</b> world</a>}, strict: true)
+    assert_dom_not_equal(canonical, %{<a>\n\t<b>hello</b> world</a>}, strict: true)
+    assert_dom_equal(canonical, %{<a><b>hello</b> world</a>}, strict: true)
+  end
+
+  def test_dom_equal_with_whitespace
+    canonical = %{<a><b>hello</b> world</a>}
+    assert_dom_equal(canonical, %{<a>\n<b>hello\n </b> world</a>})
+    assert_dom_equal(canonical, %{<a> \n <b>\n hello</b> world</a>})
+    assert_dom_equal(canonical, %{<a>\n\t<b>hello</b> world</a>})
+  end
+
+  def test_dom_equal_with_indentation
+    canonical = %{<a>hello<b>cruel</b>world</a>}
+    assert_dom_equal(canonical, <<-HTML)
+<a>
+  hello
+  <b>cruel</b>
+  world
+</a>
+    HTML
+
+    assert_dom_equal(canonical, <<-HTML)
+<a>
+hello
+<b>cruel</b>
+world
+</a>
+    HTML
+
+    assert_dom_equal(canonical, <<-HTML)
+<a>hello
+  <b>
+    cruel
+  </b>
+  world</a>
+    HTML
+  end
+
+  def test_dom_not_equal_with_interior_whitespace
+    with_space    = %{<a><b>hello world</b></a>}
+    without_space = %{<a><b>helloworld</b></a>}
+    assert_dom_not_equal(with_space, without_space)
+  end
 end


### PR DESCRIPTION
Another take on fixing #62 . This version strips any newlines, or newlines with surrounding whitespace, from the html before testing if they are equal. There is also an added option, `strict` to preserve the assertion including whitespace (default to `false`).

If we want to change this to opt in to the new behaviour we can change the default to `strict: true`.

Previous attempts: #71 and #66 