### PR TITLE
Make assert_dom_equal ignore insignificant whitespace when walking the node tree

### DIFF
--- a/lib/rails/dom/testing/assertions/dom_assertions.rb
+++ b/lib/rails/dom/testing/assertions/dom_assertions.rb
@@ -7,43 +7,61 @@ module Rails
           #
           #   # assert that the referenced method generates the appropriate HTML string
           #   assert_dom_equal '<a href="http://www.example.com">Apples</a>', link_to("Apples", "http://www.example.com")
-          def assert_dom_equal(expected, actual, message = nil)
+          def assert_dom_equal(expected, actual, message = nil, strict: false)
             expected_dom, actual_dom = fragment(expected), fragment(actual)
             message ||= "Expected: #{expected}\nActual: #{actual}"
-            assert compare_doms(expected_dom, actual_dom), message
+            assert compare_doms(expected_dom, actual_dom, strict), message
           end
 
           # The negated form of +assert_dom_equal+.
           #
           #   # assert that the referenced method does not generate the specified HTML string
           #   assert_dom_not_equal '<a href="http://www.example.com">Apples</a>', link_to("Oranges", "http://www.example.com")
-          def assert_dom_not_equal(expected, actual, message = nil)
+          def assert_dom_not_equal(expected, actual, message = nil, strict: false)
             expected_dom, actual_dom = fragment(expected), fragment(actual)
             message ||= "Expected: #{expected}\nActual: #{actual}"
-            assert_not compare_doms(expected_dom, actual_dom), message
+            assert_not compare_doms(expected_dom, actual_dom, strict), message
           end
 
           protected
 
-            def compare_doms(expected, actual)
-              return false unless expected.children.size == actual.children.size
+            def compare_doms(expected, actual, strict)
+              expected_children = extract_children(expected, strict)
+              actual_children   = extract_children(actual, strict)
+              return false unless expected_children.size == actual_children.size
 
-              expected.children.each_with_index do |child, i|
-                return false unless equal_children?(child, actual.children[i])
+              expected_children.each_with_index do |child, i|
+                return false unless equal_children?(child, actual_children[i], strict)
               end
 
               true
             end
 
-            def equal_children?(child, other_child)
+            def extract_children(node, strict)
+              if strict
+                node.children
+              else
+                node.children.reject{|n| n.text? && n.text.blank?}
+              end
+            end
+
+            def equal_children?(child, other_child, strict)
               return false unless child.type == other_child.type
 
               if child.element?
                 child.name == other_child.name &&
                     equal_attribute_nodes?(child.attribute_nodes, other_child.attribute_nodes) &&
-                    compare_doms(child, other_child)
+                    compare_doms(child, other_child, strict)
               else
+                equal_child?(child, other_child, strict)
+              end
+            end
+
+            def equal_child?(child, other_child, strict)
+              if strict
                 child.to_s == other_child.to_s
+              else
+                child.to_s.strip == other_child.to_s.strip
               end
             end
 

--- a/lib/rails/dom/testing/assertions/dom_assertions.rb
+++ b/lib/rails/dom/testing/assertions/dom_assertions.rb
@@ -61,7 +61,7 @@ module Rails
               if strict
                 child.to_s == other_child.to_s
               else
-                child.to_s.strip == other_child.to_s.strip
+                child.to_s.split == other_child.to_s.split
               end
             end
 

--- a/test/dom_assertions_test.rb
+++ b/test/dom_assertions_test.rb
@@ -100,6 +100,23 @@ world
     HTML
   end
 
+  def test_dom_equal_with_surrounding_whitespace
+    canonical = %{<p>Lorem ipsum dolor</p><p>sit amet, consectetur adipiscing elit</p>}
+    assert_dom_equal(canonical, <<-HTML)
+<p>
+  Lorem
+  ipsum
+  dolor
+</p>
+
+<p>
+  sit amet,
+  consectetur
+  adipiscing elit
+</p>
+    HTML
+  end
+
   def test_dom_not_equal_with_interior_whitespace
     with_space    = %{<a><b>hello world</b></a>}
     without_space = %{<a><b>helloworld</b></a>}

--- a/test/dom_assertions_test.rb
+++ b/test/dom_assertions_test.rb
@@ -47,4 +47,62 @@ class DomAssertionsTest < ActiveSupport::TestCase
       %{<a><b c="2" /></a>}
     )
   end
+
+  def test_dom_equal_with_whitespace_strict
+    canonical = %{<a><b>hello</b> world</a>}
+    assert_dom_not_equal(canonical, %{<a>\n<b>hello\n </b> world</a>}, strict: true)
+    assert_dom_not_equal(canonical, %{<a> \n <b>\n hello</b> world</a>}, strict: true)
+    assert_dom_not_equal(canonical, %{<a>\n\t<b>hello</b> world</a>}, strict: true)
+    assert_dom_equal(canonical, %{<a><b>hello</b> world</a>}, strict: true)
+  end
+
+  def test_dom_equal_with_whitespace
+    canonical = %{<a><b>hello</b> world</a>}
+    assert_dom_equal(canonical, %{<a>\n<b>hello\n </b> world</a>})
+    assert_dom_equal(canonical, %{<a>\n<b>hello </b>\nworld</a>})
+    assert_dom_equal(canonical, %{<a> \n <b>\n hello</b> world</a>})
+    assert_dom_equal(canonical, %{<a> \n <b> hello </b>world</a>})
+    assert_dom_equal(canonical, %{<a> \n <b>hello </b>world\n</a>\n})
+    assert_dom_equal(canonical, %{<a>\n\t<b>hello</b> world</a>})
+    assert_dom_equal(canonical, %{<a>\n\t<b>hello </b>\n\tworld</a>})
+  end
+
+  def test_dom_equal_with_attribute_whitespace
+    canonical = %(<div data-wow="Don't strip this">)
+    assert_dom_equal(canonical, %(<div data-wow="Don't strip this">))
+    assert_dom_not_equal(canonical, %(<div data-wow="Don't  strip this">))
+  end
+
+  def test_dom_equal_with_indentation
+    canonical = %{<a>hello <b>cruel</b> world</a>}
+    assert_dom_equal(canonical, <<-HTML)
+<a>
+  hello
+  <b>cruel</b>
+  world
+</a>
+    HTML
+
+    assert_dom_equal(canonical, <<-HTML)
+<a>
+hello
+<b>cruel</b>
+world
+</a>
+    HTML
+
+    assert_dom_equal(canonical, <<-HTML)
+<a>hello
+  <b>
+    cruel
+  </b>
+  world</a>
+    HTML
+  end
+
+  def test_dom_not_equal_with_interior_whitespace
+    with_space    = %{<a><b>hello world</b></a>}
+    without_space = %{<a><b>helloworld</b></a>}
+    assert_dom_not_equal(with_space, without_space)
+  end
 end


### PR DESCRIPTION
Yet another take on fixing #62

Prior art: #71, #66 and #83 

This version ignores the whitespace as we are walking the tree instead of trying to pre-process or clean the html strings. Also included a `strict` option to preserve the assertion including whitespace (default to `false`).

I'm not a fan of passing `strict` through the method calls but wasn't sure of a better approach.

Let me know what you think and if there are any changes I should make!