### PR TITLE
Update test matrix to current supported ruby/rails versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 sudo: false
 cache: bundler
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.10
   - 2.2.9
   - 2.3.6
   - 2.4.3
@@ -11,27 +8,21 @@ rvm:
   - jruby
   - ruby-head
 gemfile:
-  - gemfiles/active_support_4.2.gemfile
   - gemfiles/active_support_5.0.gemfile
+  - gemfiles/active_support_6.0.gemfile
 before_install:
   - "rm -f ${BUNDLE_GEMFILE}.lock"
 matrix:
   fast_finish: true
   exclude:
-    - rvm: 1.9.3
-      gemfile: gemfiles/active_support_5.0.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/active_support_5.0.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/active_support_5.0.gemfile
-    - rvm: 2.4.3
-      gemfile: gemfiles/active_support_4.2.gemfile
-    - rvm: 2.5.0
-      gemfile: gemfiles/active_support_4.2.gemfile
-    - rvm: ruby-head
-      gemfile: gemfiles/active_support_4.2.gemfile
     - rvm: jruby
       gemfile: gemfiles/active_support_5.0.gemfile
+    - rvm: 2.2.9
+      gemfile: gemfiles/active_support_6.0.gemfile
+    - rvm: 2.3.6
+      gemfile: gemfiles/active_support_6.0.gemfile
+    - rvm: 2.4.3
+      gemfile: gemfiles/active_support_6.0.gemfile
   allow_failures:
     - rvm: ruby-head
 notifications:

--- a/gemfiles/active_support_4.2.gemfile
+++ b/gemfiles/active_support_4.2.gemfile
@@ -1,8 +1,0 @@
-source "https://rubygems.org"
-
-gem "activesupport", "~> 4.2.0"
-
-gem "nokogiri", "~> 1.6.0"
-gem 'minitest', '< 5.12.0'
-
-gemspec path: "../"

--- a/gemfiles/active_support_6.0.gemfile
+++ b/gemfiles/active_support_6.0.gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~> 6.0.0"
+
+gem "nokogiri", ">= 1.7.0"
+
+gemspec path: "../"


### PR DESCRIPTION
Update test matrix to focus on supported versions of Ruby/Rails.

ie. Rails 6, ruby >=2.5.0 and Rails 5, ruby >= 2.2.2