### PR TITLE
Bump min version of activesupport required

### DIFF
--- a/rails-dom-testing.gemspec
+++ b/rails-dom-testing.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "nokogiri", ">= 1.6"
-  spec.add_dependency "activesupport",  ">= 4.2.0"
+  spec.add_dependency "activesupport",  ">= 5.0.0"
 
   spec.add_development_dependency "bundler", ">= 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Since we updated the test matrix to only test against supported versions of Rails, updating the minimum activesupport version to match that.

cc @chancancode 