### PR TITLE
Remove reference to AS::Concern from the codebase

### DIFF
--- a/lib/rails/dom/testing/assertions.rb
+++ b/lib/rails/dom/testing/assertions.rb
@@ -1,4 +1,3 @@
-require 'active_support/concern'
 require 'nokogiri'
 
 module Rails
@@ -7,9 +6,6 @@ module Rails
       module Assertions
         autoload :DomAssertions, 'rails/dom/testing/assertions/dom_assertions'
         autoload :SelectorAssertions, 'rails/dom/testing/assertions/selector_assertions'
-
-        extend ActiveSupport::Concern
-
         include DomAssertions
         include SelectorAssertions
       end

--- a/lib/rails/dom/testing/assertions/selector_assertions/count_describable.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions/count_describable.rb
@@ -1,13 +1,9 @@
-require 'active_support/concern'
-
 module Rails
   module Dom
     module Testing
       module Assertions
         module SelectorAssertions
           module CountDescribable
-            extend ActiveSupport::Concern
-
             private
               def count_description(min, max, count) #:nodoc:
                 if min && max && (max != min)


### PR DESCRIPTION
We can just safely get rid of `require` and `extend AS::Concern` from the whole codebase since these modules do never use (have never used) any `ActiveSupport::Concern` feature.