### PR TITLE
autoload + immediately load  =>  require

### DIFF
--- a/lib/rails/dom/testing/assertions.rb
+++ b/lib/rails/dom/testing/assertions.rb
@@ -1,11 +1,11 @@
 require 'nokogiri'
+require 'rails/dom/testing/assertions/dom_assertions'
+require 'rails/dom/testing/assertions/selector_assertions'
 
 module Rails
   module Dom
     module Testing
       module Assertions
-        autoload :DomAssertions, 'rails/dom/testing/assertions/dom_assertions'
-        autoload :SelectorAssertions, 'rails/dom/testing/assertions/selector_assertions'
         include DomAssertions
         include SelectorAssertions
       end


### PR DESCRIPTION
dom/testing/assertions.rb autoloads two constants, then immediately references these two constants a couple lines below the autoload.
It'd be better to simply `require` these files.