### PR TITLE
Expand Substitution Matching Types support

### DIFF
--- a/lib/rails/dom/testing/assertions/selector_assertions.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions.rb
@@ -96,11 +96,14 @@ module Rails
         #     assert_select "li", 8
         #   end
         #
-        # The selector may be a CSS selector expression (String) or an expression
+        # The selector may be a CSS selector expression (String, Symbol, or Numeric) or an expression
         # with substitution values (Array).
         # Substitution uses a custom pseudo class match. Pass in whatever attribute you want to match (enclosed in quotes) and a ? for the substitution.
         # assert_select returns nil if called with an invalid css selector.
         #
+        # assert_select "div:match('id', ?)", "id_string"
+        # assert_select "div:match('id', ?)", :id_string
+        # assert_select "div:match('id', ?)", 1
         # assert_select "div:match('id', ?)", /\d+/
         #
         # === Equality Tests

--- a/lib/rails/dom/testing/assertions/selector_assertions/substitution_context.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions/substitution_context.rb
@@ -28,6 +28,6 @@ class SubstitutionContext
     end
 
     def substitutable?(value)
-      value.is_a?(String) || value.is_a?(Regexp)
+      [ Symbol, Numeric, String, Regexp ].any? { |type| value.is_a? type }
     end
 end

--- a/test/selector_assertions_test.rb
+++ b/test/selector_assertions_test.rb
@@ -135,6 +135,16 @@ class AssertSelectTest < ActiveSupport::TestCase
     end
   end
 
+  def test_substitution_values_with_values_other_than_string_or_regexp
+    render_html %Q{<div id="id_string">symbol</div><div id="1">numeric</div>}
+    assert_select "div:match('id', ?)", :id_string do |elements|
+      assert_equal 1, elements.size
+    end
+    assert_select "div:match('id', ?)", 1 do |elements|
+      assert_equal 1, elements.size
+    end
+  end
+
   def test_assert_select_root_html
     render_html '<a></a>'
 


### PR DESCRIPTION
Add substitution support for `Symbol` and `Numeric`. It can be
convenient to pass in the value of an `ActiveRecord::Base#id`, or a
`Symbol` declared elsewhere in the test.