### PR TITLE
Deprecate assert_select* in preparation for rename

### DIFF
--- a/lib/rails/dom/testing/assertions/selector_assertions.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions.rb
@@ -178,6 +178,7 @@ module Rails
             nest_selection(matches, &block) if block_given? && !matches.empty?
           end
         end
+        deprecate assert_select: "assert_select will be renamed to assert_dom in an upcoming release"
 
         # Extracts the content of an element, treats it as encoded HTML and runs
         # nested assertion on it.
@@ -231,6 +232,7 @@ module Rails
             end
           end
         end
+        deprecate assert_select_encoded: "assert_select_encoded will be renamed to assert_dom_encoded in an upcoming release"
 
         # Extracts the body of an email and runs nested assertions on it.
         #
@@ -260,6 +262,7 @@ module Rails
             end
           end
         end
+        deprecate assert_select_email: "assert_select_email will be renamed to assert_dom_email in an upcoming release"
 
         private
           include CountDescribable


### PR DESCRIPTION
This change is a companion PR to [rails/rails#41291][]. While it's
possible that [rails/rails#41291][] may make Capybara assertion
integration possible, there is still a possibility that applications
would continue to use rails-dom-testing (or both!) to make assertions
about HTML.

Capybara also declares an `assert_select` method and while the method
names collide, "select" in one case means CSS selector while "select"
means `<select>` elements in the other.

Since the tool itself includes `dom` in the package name, and includes
`assert_dom_equal` helpers already, renaming `assert_select` and its
other variations to methods starting with `assert_dom` unifies the
interface.

[rails/rails#41291]: https://github.com/rails/rails/pull/41291