### PR TITLE
Alias assert_select methods to assert_dom versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,31 +1,30 @@
 PATH
   remote: .
   specs:
-    rails-dom-testing (2.0.2)
-      activesupport (>= 4.2.0)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 5.0.0)
       nokogiri (>= 1.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.1)
+    activesupport (6.1.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
-    concurrent-ruby (1.1.6)
-    i18n (1.8.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    concurrent-ruby (1.1.8)
+    i18n (1.8.9)
       concurrent-ruby (~> 1.0)
-    mini_portile2 (2.4.0)
     minitest (5.10.1)
-    nokogiri (1.10.9)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.1)
+      racc (~> 1.4)
+    racc (1.5.2)
     rake (13.0.1)
-    thread_safe (0.3.6)
-    tzinfo (1.2.7)
-      thread_safe (~> 0.1)
-    zeitwerk (2.3.0)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby

--- a/lib/rails/dom/testing/assertions/selector_assertions.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions.rb
@@ -178,6 +178,7 @@ module Rails
             nest_selection(matches, &block) if block_given? && !matches.empty?
           end
         end
+        alias_method :assert_dom, :assert_select
         deprecate assert_select: "assert_select will be renamed to assert_dom in an upcoming release"
 
         # Extracts the content of an element, treats it as encoded HTML and runs
@@ -232,6 +233,7 @@ module Rails
             end
           end
         end
+        alias_method :assert_dom_encoded, :assert_select_encoded
         deprecate assert_select_encoded: "assert_select_encoded will be renamed to assert_dom_encoded in an upcoming release"
 
         # Extracts the body of an email and runs nested assertions on it.
@@ -262,6 +264,7 @@ module Rails
             end
           end
         end
+        alias_method :assert_dom_email, :assert_select_email
         deprecate assert_select_email: "assert_select_email will be renamed to assert_dom_email in an upcoming release"
 
         private

--- a/test/selector_assertions_test.rb
+++ b/test/selector_assertions_test.rb
@@ -21,6 +21,7 @@ class AssertSelectTest < ActiveSupport::TestCase
   def test_assert_select
     render_html %Q{<div id="1"></div><div id="2"></div>}
     assert_select "div", 2
+    assert_dom "div", 2
     assert_failure(/Expected at least 1 element matching \"p\", found 0/) { assert_select "p" }
   end
 
@@ -275,6 +276,9 @@ EOF
     assert_select "channel item description" do
 
       assert_select_encoded do
+        assert_select "p", :count=>2, :text=>/Test/
+      end
+      assert_dom_encoded do
         assert_select "p", :count=>2, :text=>/Test/
       end
 


### PR DESCRIPTION
Bridge the gap between [#91][] (shipped) and [#92][] (open) by declaring
[alias_method][] expressions for each `assert_select` variation, adding
`assert_dom` variations to the interface.

[#91]: https://github.com/rails/rails-dom-testing/pull/91
[#92]: https://github.com/rails/rails-dom-testing/pull/92
[alias_method]: https://docs.ruby-lang.org/en/3.0.0/Module.html#method-i-alias_method