### PR TITLE
Change `assert_dom` to scope with NodeSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ css_select '.hello' # => Nokogiri::XML::NodeSet of elements with hello class
 # select from a supplied node. assert_dom asserts elements exist.
 assert_dom document_root_element.at('.hello'), '.goodbye'
 
+# explicitly modifies the document_root_element for the supplied node and block
+assert_dom document_root_element.at('.hello') do
+  assert_dom 'p', 'Hello!'
+end
+
 # elements in CDATA encoded sections can also be selected
 assert_dom_encoded '#out-of-your-element'
 

--- a/lib/rails/dom/testing/assertions/selector_assertions.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions.rb
@@ -160,6 +160,16 @@ module Rails
         #   assert_dom "form input" do
         #     assert_dom ":match('name', ?)", /.+/  # Not empty
         #   end
+        #
+        #   # move the document_root_element to a node
+        #   assert_dom document_root_element.at_css("main") do
+        #     assert_dom "h1", "Hello, World"
+        #   end
+        #
+        #   # move the document_root_element to a Nodeset
+        #   assert_dom css_select("section") do
+        #     assert_dom "h1"
+        #   end
         def assert_dom(*args, &block)
           @selected ||= nil
 
@@ -269,6 +279,10 @@ module Rails
           def document_root_element
             raise NotImplementedError, 'Implementing document_root_element makes ' \
               'assert_dom work without needing to specify an element to select from.'
+          end
+
+          def current_root_element
+            @selected || document_root_element
           end
 
           # +equals+ must contain :minimum, :maximum and :count keys


### PR DESCRIPTION
Change `assert_dom` to accept a single `Nokogiri::XML::Node` or a
`Nokogiri::XML::NodeSet` as an argument without supplementary set of CSS
or XPath selectors.

```ruby
assert_dom document_root_element.at_css("main") do
  assert_dom "h1", "Hello, World"
end

assert_dom css_select("section") do
  assert_dom "h1"
end
```

This change is in support of making [rails/rails#41291][] possible:

```diff
require "test_helper"
+ require "capybara/minitest"

class ActionDispatch::IntegrationTest
+  include Capybara::Minitest::Assertions
+
+  def page
+    Capybara.string(current_root_element)
+  end
+
+  def within(*arguments, **options, &block)
+    assert_dom page.find(*arguments, **options).native, &block
+  end
end
```

[rails/rails#41291]: https://github.com/rails/rails/pull/41291
