### PR TITLE
Raise an error if the last arg is the wrong format

### DIFF
--- a/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb
@@ -11,6 +11,10 @@ class HTMLSelector #:nodoc:
     @tests = extract_equality_tests
     @message = @values.shift
 
+    if @message.is_a?(Hash)
+      raise ArgumentError, "Last argument was a Hash, which would be used for the assertion message. You probably want this to be a String, or you have the wrong type of arguments."
+    end
+
     if @values.shift
       raise ArgumentError, "Not expecting that last argument, you either have too many arguments, or they're the wrong type"
     end

--- a/test/selector_assertions_test.rb
+++ b/test/selector_assertions_test.rb
@@ -312,6 +312,16 @@ EOF
     assert_select '.foo'
   end
 
+  def test_assert_select_with_extra_argument
+    render_html '<html><head><title>Welcome</title></head><body><div></div></body></html>'
+
+    assert_raises ArgumentError do
+      assert_select "title", "Welcome", count: 1
+    end
+
+    assert_select "title", text: "Welcome", count: 1
+  end
+
   protected
     def render_html(html)
       fake_render(:html, html)


### PR DESCRIPTION
I always accidentally write this:

```ruby
assert_select "title", "Welcome", count: 1
```

When I mean to write this:

```ruby
assert_select "title", text: "Welcome", count: 1
```

The first assertion is incorrect; it's looking for the string "Welcome", then using `{ count: 1 }` as the assertion failure message if it's not found. So for example, if you change the text to `count: 2` or `count: 0` your test could behave wrong.

Since the assertion failure message probably should not be a hash, I propose we raise an error if that argument is passed. This would make it easier to identify incorrectly written tests.