### PR TITLE
Better error message if response.body is blank or not parseable by Nokogiri

### DIFF
--- a/lib/rails/dom/testing/assertions/selector_assertions.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions.rb
@@ -297,6 +297,7 @@ module Rails
             if node.is_a?(Nokogiri::XML::NodeSet)
               node
             else
+              node ||= Nokogiri::HTML::Document.new
               Nokogiri::XML::NodeSet.new(node.document, [node])
             end
           end

--- a/test/selector_assertions_test.rb
+++ b/test/selector_assertions_test.rb
@@ -322,6 +322,14 @@ EOF
     assert_select "title", text: "Welcome", count: 1
   end
 
+  def test_assert_select_on_blank_response
+    render_html ""
+    assert_select "div", 0
+    assert_failure(/Expected exactly 1 element matching \"div\", found 0./) do
+      assert_select "div", 1
+    end
+  end
+
   protected
     def render_html(html)
       fake_render(:html, html)


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/44634

Open to ideas, but I think it's best to raise aggressively here since currently (or at least, before https://github.com/rails/rails/pull/44554) your tests might be incorrectly passing because of this behaviour.