### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: build
+
+on: [pull_request, push]
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '3.1'
+          - '3.0'
+          - '2.7'
+          - '2.6'
+          - '2.5'
+          - ruby-head
+          - jruby
+        activesupport:
+          - '7.0'
+          - '6.1'
+          - '6.0'
+          - '5.2'
+        exclude:
+          - ruby: '2.5'
+            activesupport: '7.0'
+          - ruby: '2.6'
+            activesupport: '7.0'
+          - ruby: '2.7'
+            activesupport: '5.2'
+          - ruby: '3.0'
+            activesupport: '5.2'
+          - ruby: '3.0'
+            activesupport: '6.0'
+          - ruby: '3.1'
+            activesupport: '5.2'
+          - ruby: '3.1'
+            activesupport: '6.0'
+          - ruby: ruby-head
+            activesupport: '5.2'
+          - ruby: ruby-head
+            activesupport: '6.0'
+          - ruby: ruby-head
+            activesupport: '6.1'
+          - ruby: jruby
+            activesupport: '7.0'
+    env:
+      BUNDLE_GEMFILE: gemfiles/active_support_${{ matrix.activesupport }}.gemfile
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - run: bundle exec rake

--- a/gemfiles/active_support_5.2.gemfile
+++ b/gemfiles/active_support_5.2.gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~> 5.2.0"
+
+gem "nokogiri", ">= 1.7.0"
+
+gemspec path: "../"

--- a/gemfiles/active_support_6.1.gemfile
+++ b/gemfiles/active_support_6.1.gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~> 6.1.0"
+
+gem "nokogiri", ">= 1.7.0"
+
+gemspec path: "../"

--- a/gemfiles/active_support_7.0.gemfile
+++ b/gemfiles/active_support_7.0.gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~> 7.0.0"
+
+gem "nokogiri", ">= 1.7.0"
+
+gemspec path: "../"


### PR DESCRIPTION
Migrates CI to GitHub Actions as Travis CI.org is no longer active.  Adds gemfiles for recent ActiveSupport minor releases.

I restricted to Ruby >= 2.5 and Rails >= 5.2.  To match up with the Travis config I included a jruby line and a ruby-head line.

This all runs green on my fork.