### PR TITLE
Bumps various versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,28 +3,26 @@ PATH
   specs:
     rails-dom-testing (2.0.3)
       activesupport (>= 5.0.0)
-      nokogiri (>= 1.6)
+      nokogiri (>= 1.13.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.2.1)
+    activesupport (7.0.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
-    concurrent-ruby (1.1.8)
-    i18n (1.8.9)
+    concurrent-ruby (1.1.10)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     minitest (5.10.1)
-    nokogiri (1.11.1)
+    nokogiri (1.13.3)
       racc (~> 1.4)
-    racc (1.5.2)
+    racc (1.6.0)
     rake (13.0.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby

--- a/rails-dom-testing.gemspec
+++ b/rails-dom-testing.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir["test/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "nokogiri", ">= 1.6"
+  spec.add_dependency "nokogiri", ">= 1.13.2"
   spec.add_dependency "activesupport",  ">= 5.0.0"
 
   spec.add_development_dependency "bundler", ">= 1.3"


### PR DESCRIPTION
Based on this PR https://github.com/rails/rails/pull/44774 and this Security Advisory https://github.com/advisories/GHSA-fq42-c5rg-92c2, I've updated
`nokogiri`, and did `bundle install` to fetch the latest versions on to `Gemfile.lock`