### PR TITLE
selector_assertions/html_selector: No trailing `.` on `content_mismatch`

### DIFF
--- a/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb
@@ -52,7 +52,7 @@ class HTMLSelector #:nodoc:
       content.sub!(/\A\n/, '') if text_matches && match.name == "textarea"
 
       next if regex_matching ? (content =~ match_with) : (content == match_with)
-      content_mismatch ||= sprintf("<%s> expected but was\n<%s>.", match_with, content)
+      content_mismatch ||= sprintf("<%s> expected but was\n<%s>", match_with, content)
       true
     end
 


### PR DESCRIPTION
- I was refreshing my Rails knowledge by following a Rails tutorial (but with the latest gem versions) and I found that when I used `assert_select` and it failed, the message was printed like:

```
  1) Failure:
StaticPagesControllerTest#test_should_get_about [/Users/issyl0/repos/issyl0/rails-tutorial/sample_app/test/controllers/static_pages_controller_test.rb:24]:
<About | Ruby on Rails Tutorial Sample App> expected but was
<About| Ruby on Rails Tutorial Sample App>..
Expected 0 to be >= 1.
```

- That is, the "expected but was" sentence ends with two periods. There's an example of this output in the [release notes for Rails 4.2 about `assert_select` behaviour changes](https://edgeguides.rubyonrails.org/4_2_release_notes.html#assert-select), so it's pretty old. But even so, the two periods to end the sentence looked weird to me.
- I did look at the MiniTest code to see if I could upstream this further (`if message.end_with?(".")` then don't add another period, or something), but I couldn't find the place to do it and I was also surprised that someone else hadn't noticed this before, so I thought I'd leave that alone as there are probably reasons that are way beyond my levels of understanding of the interactions between MiniTest's core functionality vs. this gem!