### PR TITLE
ci: add Ruby 3.2 coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,46 +20,35 @@ on:
 
 jobs:
   test:
+    name: "activesupport ${{ matrix.activesupport }} / ruby ${{ matrix.ruby }}"
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        ruby:
-          - '3.1'
-          - '3.0'
-          - '2.7'
-          - '2.6'
-          - '2.5'
-          - ruby-head
-          - jruby
-        activesupport:
-          - '7.0'
-          - '6.1'
-          - '6.0'
-          - '5.2'
-        exclude:
-          - ruby: '2.5'
-            activesupport: '7.0'
-          - ruby: '2.6'
-            activesupport: '7.0'
-          - ruby: '2.7'
-            activesupport: '5.2'
-          - ruby: '3.0'
-            activesupport: '5.2'
-          - ruby: '3.0'
-            activesupport: '6.0'
-          - ruby: '3.1'
-            activesupport: '5.2'
-          - ruby: '3.1'
-            activesupport: '6.0'
-          - ruby: ruby-head
-            activesupport: '5.2'
-          - ruby: ruby-head
-            activesupport: '6.0'
-          - ruby: ruby-head
-            activesupport: '6.1'
-          - ruby: jruby
-            activesupport: '7.0'
+        include:
+          # rails 5.2
+          - { activesupport: "5.2", ruby: "2.5" }
+          - { activesupport: "5.2", ruby: "2.6" }
+          # rails 6.0
+          - { activesupport: "6.0", ruby: "2.5" }
+          - { activesupport: "6.0", ruby: "2.6" }
+          - { activesupport: "6.0", ruby: "2.7" }
+          # rails 6.1
+          - { activesupport: "6.1", ruby: "2.5" }
+          - { activesupport: "6.1", ruby: "2.6" }
+          - { activesupport: "6.1", ruby: "2.7" }
+          - { activesupport: "6.1", ruby: "3.0" }
+          - { activesupport: "6.1", ruby: "3.1" }
+          - { activesupport: "6.1", ruby: "3.2" }
+          - { activesupport: "6.1", ruby: "ruby-head" }
+          - { activesupport: "6.1", ruby: "jruby" }
+          # rails 7.0
+          - { activesupport: "7.0", ruby: "2.7" }
+          - { activesupport: "7.0", ruby: "3.0" }
+          - { activesupport: "7.0", ruby: "3.1" }
+          - { activesupport: "7.0", ruby: "3.2" }
+          - { activesupport: "7.0", ruby: "ruby-head" }
+          - { activesupport: "7.0", ruby: "jruby" }
     env:
       BUNDLE_GEMFILE: gemfiles/active_support_${{ matrix.activesupport }}.gemfile
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,16 @@
 
 name: build
 
-on: [pull_request, push]
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   test:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,26 +8,24 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.2.1)
+    activesupport (7.0.5.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
-    concurrent-ruby (1.1.8)
-    i18n (1.8.9)
+    concurrent-ruby (1.2.2)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    minitest (5.10.1)
-    nokogiri (1.11.1)
+    minitest (5.18.1)
+    nokogiri (1.15.2-x86_64-linux)
       racc (~> 1.4)
-    racc (1.5.2)
-    rake (13.0.1)
-    tzinfo (2.0.4)
+    racc (1.7.1)
+    rake (13.0.6)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.4.2)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   bundler (>= 1.3)
@@ -36,4 +34,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.13.7
+   2.4.14


### PR DESCRIPTION
- add Ruby 3.2 coverage to CI
- update the CI pipeline to cancel in progress and allow workflow dispatch.
- give the tests a more descriptive name
- matrix uses includes instead of excludes
- sort order of tests is AS first, Ruby second
- update Gemfile.lock
