### PR TITLE
Use Minitest::Assertion#diff for content failure messages

### DIFF
--- a/lib/rails/dom/testing/assertions/selector_assertions.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions.rb
@@ -275,7 +275,7 @@ module Rails
           def assert_size_match!(size, equals, css_selector, message = nil)
             min, max, count = equals[:minimum], equals[:maximum], equals[:count]
 
-            message ||= %(Expected #{count_description(min, max, count)} matching "#{css_selector}", found #{size}.)
+            message ||= %(Expected #{count_description(min, max, count)} matching #{css_selector.inspect}, found #{size})
             if count
               assert_equal count, size, message
             else

--- a/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb
@@ -4,6 +4,8 @@ require_relative 'substitution_context'
 class HTMLSelector #:nodoc:
   attr_reader :css_selector, :tests, :message
 
+  include Minitest::Assertions
+
   def initialize(values, previous_selection = nil, &root_fallback)
     @values = values
     @root = extract_root(previous_selection, root_fallback)
@@ -52,7 +54,7 @@ class HTMLSelector #:nodoc:
       content.sub!(/\A\n/, '') if text_matches && match.name == "textarea"
 
       next if regex_matching ? (content =~ match_with) : (content == match_with)
-      content_mismatch ||= sprintf("<%s> expected but was\n<%s>", match_with, content)
+      content_mismatch ||= diff(match_with, content)
       true
     end
 


### PR DESCRIPTION
So where it previously would output:

    <
    "This is not a big problem," he said.
    > expected but was
    <"This is not a big problem," he said.
    >.
    Expected 0 to be >= 1.

it now outputs:

    --- expected
    +++ actual
    @@ -1,3 +1,2 @@
    -"
    -\"This is not a big problem,\" he said.
    +"\"This is not a big problem,\" he said.
     "
    .
    Expected 0 to be >= 1.

Also improve the count failure message.