### PR TITLE
Fix string substitution regression

### DIFF
--- a/lib/rails/dom/testing/assertions/selector_assertions/substitution_context.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions/substitution_context.rb
@@ -24,7 +24,7 @@ module Rails
             private
               def matcher_for(value, format_for_presentation)
                 # Nokogiri doesn't like arbitrary values without quotes, hence inspect.
-                if format_for_presentation
+                if format_for_presentation || value.is_a?(String)
                   value.inspect # Avoid to_s so Regexps aren't put in quotes.
                 else
                   "\"#{value}\""

--- a/lib/rails/dom/testing/assertions/selector_assertions/substitution_context.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions/substitution_context.rb
@@ -24,10 +24,12 @@ module Rails
             private
               def matcher_for(value, format_for_presentation)
                 # Nokogiri doesn't like arbitrary values without quotes, hence inspect.
-                if format_for_presentation || value.is_a?(String)
+                if format_for_presentation
                   value.inspect # Avoid to_s so Regexps aren't put in quotes.
-                else
+                elsif value.is_a?(Regexp)
                   "\"#{value}\""
+                else
+                  value.to_s.inspect
                 end
               end
 

--- a/test/selector_assertions_test.rb
+++ b/test/selector_assertions_test.rb
@@ -136,6 +136,11 @@ class AssertSelectTest < ActiveSupport::TestCase
     end
   end
 
+  def test_substitution_value_with_quotes
+    render_html '<input placeholder="placeholder with &quot;quotes&quot;" />'
+    assert_select "input[placeholder=?]", 'placeholder with "quotes"'
+  end
+
   def test_multiple_substitution_values
     render_html '<input name="foo[12]" value="34">'
     assert_select ":match('name', ?):match('value', ?)", /\w+\[\d+\]/, /\d+/


### PR DESCRIPTION
Some of our tests started failing when updating from version 2.0.3. After some investigation, it turns out [this change](https://github.com/rails/rails-dom-testing/commit/117d2848d6df79c95defd00e0cefc586f7ae45b0#diff-141b7ea4f628744eabc535269fb5a5281b87faa60b45c0fc8b5f43074228a0d0L26) from #76 is the culprit &ndash; quotation marks are no longer escaped if the substitution value is a string since `inspect` isn't being called anymore. Reverting the change isn't possible since it would break some regular expressions so I've just added an exception here for strings.