### PR TITLE
ci: add mutex_m to the rails 7.0 gemfile

### DIFF
--- a/gemfiles/active_support_7.0.gemfile
+++ b/gemfiles/active_support_7.0.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "activesupport", "~> 7.0.0"
 
 gem "nokogiri", ">= 1.7.0"
+gem "mutex_m" # for ruby 3.4.0-dev
 
 gemspec path: "../"


### PR DESCRIPTION
attempt to work around mutex_m being removed from default gems on ruby 3.4.0-dev