### PR TITLE
assert_dom strict parameter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb
@@ -18,6 +18,7 @@ module Rails
               @values = values
               @root = extract_root(previous_selection, root_fallback)
               extract_selectors
+              @strict = false
               @tests = extract_equality_tests(refute)
               @message = @values.shift
 
@@ -59,6 +60,7 @@ module Rails
 
                   content.strip! unless NO_STRIP.include?(match.name)
                   content.delete_prefix!("\n") if text_matches && match.name == "textarea"
+                  collapse_html_whitespace!(content) unless NO_STRIP.include?(match.name) || @strict
 
                   next if regex_matching ? (content =~ match_with) : (content == match_with)
                   content_mismatch ||= diff(match_with, content)
@@ -136,7 +138,13 @@ module Rails
                   raise ArgumentError, "Range begin or :minimum cannot be greater than Range end or :maximum"
                 end
 
+                @strict = comparisons[:strict]
+
                 comparisons
+              end
+
+              def collapse_html_whitespace!(text)
+                text.gsub!(/\s+/, " ")
               end
           end
         end

--- a/test/selector_assertions_test.rb
+++ b/test/selector_assertions_test.rb
@@ -237,6 +237,73 @@ class AssertSelectTest < ActiveSupport::TestCase
     assert_equal "Range begin or :minimum cannot be greater than Range end or :maximum", error.message
   end
 
+  def test_assert_select_not_strict_collapses_whitespace
+    render_html "<p>Some\n   line-broken\n   text</p>"
+
+    assert_nothing_raised do
+      assert_select "p", {
+        text: "Some line-broken text",
+        strict: false
+      }, "Whitespace was not collapsed from text when not strict"
+
+      assert_select "p", {
+        html: "Some line-broken text",
+        strict: false
+      }, "Whitespace was not collapsed from html when not strict"
+    end
+
+    render_html "<p>Some<br><br>line-broken<br><br>text</p>"
+
+    assert_nothing_raised do
+      assert_select "p", {
+        text: "Someline-brokentext",
+        strict: false
+      }, "<br> was not removed from text when not strict"
+
+      assert_select "p", {
+        html: "Some<br><br>line-broken<br><br>text",
+        strict: false
+      }, "<br> was removed from html when not strict"
+    end
+  end
+
+  def test_assert_select_strict_respects_whitespace
+    render_html "<p>Some\n   line-broken\n   text</p>"
+
+    assert_nothing_raised do
+      assert_select "p", {
+        text: "Some\n   line-broken\n   text",
+        strict: true
+      }, "Whitespace was collapsed from text when strict"
+
+      assert_select "p", {
+        html: "Some\n   line-broken\n   text",
+        strict: true
+      }, "Whitespace was collapsed from html when strict"
+    end
+
+    assert_raises(Assertion) do
+      assert_select "p", {
+        html: "Some line-broken text",
+        strict: true
+      }
+    end
+
+    render_html "<p>Some<br><br>line-broken<br><br>text</p>"
+
+    assert_nothing_raised do
+      assert_select "p", {
+        text: "Someline-brokentext",
+        strict: true
+      }, "<br> was not removed from text when strict"
+
+      assert_select "p", {
+        html: "Some<br><br>line-broken<br><br>text",
+        strict: true
+      }, "<br> was removed from html when strict"
+    end
+  end
+
   #
   # Test assert_not_select.
   #


### PR DESCRIPTION
- **Add macos to supported platforms in Gemfile.lock**
- **Add failing test for assert_dom collapsing whitespace**
- **Add strict parameter to assert_dom**

Fixes #121

Adds a `:strict` key to the equality test hash for `assert_dom`, so that we can specify whether or not to ignore excess whitespace just as the browser does.

I prefer the solution in #123. This was created since the issue I created specifically mentioned creating a `:strict` parameter.
