### PR TITLE
assert_dom :text collapses whitespace

### DIFF
--- a/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb
@@ -18,7 +18,6 @@ module Rails
               @values = values
               @root = extract_root(previous_selection, root_fallback)
               extract_selectors
-              @strict = false
               @tests = extract_equality_tests(refute)
               @message = @values.shift
 
@@ -52,15 +51,16 @@ module Rails
 
                 content_mismatch = nil
                 text_matches = tests.has_key?(:text)
+                html_matches = tests.has_key?(:html)
                 regex_matching = match_with.is_a?(Regexp)
 
                 remaining = matches.reject do |match|
                   # Preserve markup with to_s for html elements
-                  content = text_matches ? match.text : match.children.to_s
+                  content = text_matches ? match.text : match.inner_html
 
                   content.strip! unless NO_STRIP.include?(match.name)
                   content.delete_prefix!("\n") if text_matches && match.name == "textarea"
-                  collapse_html_whitespace!(content) unless NO_STRIP.include?(match.name) || @strict
+                  collapse_html_whitespace!(content) unless NO_STRIP.include?(match.name) || html_matches
 
                   next if regex_matching ? (content =~ match_with) : (content == match_with)
                   content_mismatch ||= diff(match_with, content)

--- a/test/selector_assertions_test.rb
+++ b/test/selector_assertions_test.rb
@@ -237,19 +237,13 @@ class AssertSelectTest < ActiveSupport::TestCase
     assert_equal "Range begin or :minimum cannot be greater than Range end or :maximum", error.message
   end
 
-  def test_assert_select_not_strict_collapses_whitespace
+  def test_assert_select_text_equality_collapses_whitespace
     render_html "<p>Some\n   line-broken\n   text</p>"
 
     assert_nothing_raised do
       assert_select "p", {
         text: "Some line-broken text",
-        strict: false
-      }, "Whitespace was not collapsed from text when not strict"
-
-      assert_select "p", {
-        html: "Some line-broken text",
-        strict: false
-      }, "Whitespace was not collapsed from html when not strict"
+      }, "Whitespace was not collapsed from text"
     end
 
     render_html "<p>Some<br><br>line-broken<br><br>text</p>"
@@ -257,50 +251,25 @@ class AssertSelectTest < ActiveSupport::TestCase
     assert_nothing_raised do
       assert_select "p", {
         text: "Someline-brokentext",
-        strict: false
-      }, "<br> was not removed from text when not strict"
-
-      assert_select "p", {
-        html: "Some<br><br>line-broken<br><br>text",
-        strict: false
-      }, "<br> was removed from html when not strict"
+      }, "<br> was not removed from text"
     end
   end
 
-  def test_assert_select_strict_respects_whitespace
+  def test_assert_select_html_equality_respects_whitespace
     render_html "<p>Some\n   line-broken\n   text</p>"
 
     assert_nothing_raised do
       assert_select "p", {
-        text: "Some\n   line-broken\n   text",
-        strict: true
-      }, "Whitespace was collapsed from text when strict"
-
-      assert_select "p", {
         html: "Some\n   line-broken\n   text",
-        strict: true
-      }, "Whitespace was collapsed from html when strict"
-    end
-
-    assert_raises(Assertion) do
-      assert_select "p", {
-        html: "Some line-broken text",
-        strict: true
-      }
+      }, "Whitespace was collapsed from html"
     end
 
     render_html "<p>Some<br><br>line-broken<br><br>text</p>"
 
     assert_nothing_raised do
       assert_select "p", {
-        text: "Someline-brokentext",
-        strict: true
-      }, "<br> was not removed from text when strict"
-
-      assert_select "p", {
         html: "Some<br><br>line-broken<br><br>text",
-        strict: true
-      }, "<br> was removed from html when strict"
+      }, "<br> was removed from html"
     end
   end
 


### PR DESCRIPTION
- **Add macos to supported platforms in Gemfile.lock**
- **Add failing test for assert_dom collapsing whitespace**
- **Collapse whitespace from :text but not :html**

Fixes #121

This PR is my preferred solution over #122.

Instead of making use of a `:strict` operator to determine whether or not to collapse excess whitespace as the browser does, we instead use the existing `:html` equality operator to match for text with all whitespace included. The `:text` equality operator is then optimised to collapse all whitespace.

In my opinion, `:text` should match what would be returned by `Element.innerText` in javascript land, in that it does not include the excess whitespace. `Element.innerHTML` on the other hand, does include all of the whitespace that was in the document which I think is what the `:html` operator should match (which it does already) and so `:html` could instead be used as a `:strict` parameter.

The only difference between what `Element.innerText` and the updated `:text` equality operator does is that `Element.innerText` replaces `<br>` tags with `\n`, whereas our `:text` operator just removes them without replacing them. But this is out of our control as it is Nokogiri that does this. Regardless, this is my preferred solution but I made the two PRs since the original issue I raised specifically mentions a `strict` parameter.
