### PR TITLE
Fix `assert_not_select` on body for text or html

### DIFF
--- a/lib/rails/dom/testing/assertions/selector_assertions.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions.rb
@@ -191,11 +191,7 @@ module Rails
           alias_method :refute_select, :assert_not_dom
 
           private def dom_assertions(selector, &block)
-            if selector.selecting_no_body?
-              assert true
-              return
-            end
-
+            selector.ensure_no_assertion_on_nokogiri_body!
             count, max = selector.tests.slice(:count, :maximum).values
 
             selector.select.tap do |matches|

--- a/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions/html_selector.rb
@@ -30,10 +30,10 @@ module Rails
               end
             end
 
-            def selecting_no_body? # :nodoc:
-              # Nokogiri gives the document a body element. Which means we can't
-              # run an assertion expecting there to not be a body.
-              @selector == "body" && @tests[:count] == 0
+            def ensure_no_assertion_on_nokogiri_body! # :nodoc:
+              # Nokogiri gives the document a body element when missing
+              return unless @selector == "body" && (@tests.keys & [:text, :html]).none?
+              raise ArgumentError, "Assertions on body can only be for text or html"
             end
 
             def select

--- a/test/selector_assertions_test.rb
+++ b/test/selector_assertions_test.rb
@@ -477,7 +477,8 @@ class AssertSelectTest < ActiveSupport::TestCase
 
   def test_body_not_present_in_empty_document
     render_html "<div></div>"
-    assert_select "body", 0
+    error = assert_raises(ArgumentError) { assert_select "body", 0 }
+    assert_equal "Assertions on body can only be for text or html", error.message
   end
 
   def test_body_class_can_be_tested
@@ -488,6 +489,17 @@ class AssertSelectTest < ActiveSupport::TestCase
   def test_body_class_can_be_tested_with_html
     render_html '<html><body class="foo"><div></div></body></html>'
     assert_select ".foo"
+  end
+
+  def test_assert_not_select_on_body_with_text
+    render_html "<div><p>foo</p><p>bar</p></div>"
+    assert_failure(/Expected exactly 0 elements matching "body", found 1/) { assert_not_select "body", "foobar" }
+    assert_failure(/Expected exactly 0 elements matching "body", found 1/) { assert_not_select "body", /foo/ }
+  end
+
+  def test_assert_not_select_on_body_with_html
+    render_html "<div>foo</div>"
+    assert_failure(/Expected exactly 0 elements matching "body", found 1/) { assert_not_select "body", { html: "<div>foo</div>" } }
   end
 
   def test_assert_select_with_extra_argument


### PR DESCRIPTION
Hey!

First of all, thank you so much for your work on this gem 🙏

While working on a project, I wrote the following test:

```ruby
get foo_path
assert_dom "body", /bar/
make_bar_disappear_in_the_body
get foo_path
assert_not_dom "body", /bar/
```

The problem is that, with the current code, the last assertion always passes (even with "bar" in the body).

This PR fixes it.