### PR TITLE
Fix documentation formatting in SelectorAssertions#assert_dom

### DIFF
--- a/lib/rails/dom/testing/assertions/selector_assertions.rb
+++ b/lib/rails/dom/testing/assertions/selector_assertions.rb
@@ -100,10 +100,10 @@ module Rails
           # Substitution uses a custom pseudo class match. Pass in whatever attribute you want to match (enclosed in quotes) and a ? for the substitution.
           # assert_dom returns nil if called with an invalid css selector.
           #
-          # assert_dom "div:match('id', ?)", "id_string"
-          # assert_dom "div:match('id', ?)", :id_string
-          # assert_dom "div:match('id', ?)", 1
-          # assert_dom "div:match('id', ?)", /\d+/
+          #  assert_dom "div:match('id', ?)", "id_string"
+          #  assert_dom "div:match('id', ?)", :id_string
+          #  assert_dom "div:match('id', ?)", 1
+          #  assert_dom "div:match('id', ?)", /\d+/
           #
           # === Equality Tests
           #


### PR DESCRIPTION
Code block needs to be indented to be rendered properly.

Here's the before and after in RubyMine:
<img width="955" height="246" alt="Screenshot From 2025-11-25 09-19-30" src="https://github.com/user-attachments/assets/6e31d9f7-5359-461c-b1d3-a056b1d5abab" />

<img width="955" height="246" alt="Screenshot From 2025-11-25 09-20-14" src="https://github.com/user-attachments/assets/d5164050-7ed9-4a4e-999f-f4f71398e137" />
