### PR TITLE
Reduce gem size by excluding test files

### DIFF
--- a/rails-dom-testing.gemspec
+++ b/rails-dom-testing.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5.0"
 
   spec.files         = Dir["lib/**/*", "README.md", "MIT-LICENSE", "CHANGELOG.md"]
-  spec.test_files    = Dir["test/**/*"]
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport",  ">= 5.0.0"


### PR DESCRIPTION
This pull request updates the *.gemspec file to optimize the gem package size and structure

```bash
$ gem build -o before.tar

$ git switch reduce-gem-size

$ gem build -o after.tar

$ du -sh before.tar after.tar
 20K	before.tar
 16K	after.tar
 ```
 
| Metric | Before | After | Saved                 |
|--------|--------|-------|-----------------------|
| Size   | 20K   | 16K   | −4K (⏷ −20%)     |


###  whitch files was deleted?

```diff
data
 ├── lib
 │   ├── rails
 │   │   └── dom
 │   │       ├── testing
 │   │       │   ├── assertions
 │   │       │   │   ├── dom_assertions.rb
 │   │       │   │   ├── selector_assertions
 │   │       │   │   │   ├── html_selector.rb
 │   │       │   │   │   └── substitution_context.rb
 │   │       │   │   └── selector_assertions.rb
 │   │       │   ├── assertions.rb
 │   │       │   ├── railtie.rb
 │   │       │   └── version.rb
 │   │       └── testing.rb
 │   └── rails-dom-testing.rb
 ├── MIT-LICENSE
 ├── README.md
-└── test
-    ├── dom_assertions_test.rb
-    ├── parser_selection_test.rb
-    ├── selector_assertions_test.rb
-    └── test_helper.rb
```